### PR TITLE
Support for several courses

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,7 @@ recursive-include syllabus/static *
 recursive-include syllabus/doc *
 recursive-include syllabus/templates *
 recursive-include syllabus/default *
+recursive-include syllabus/admin *
+recursive-include syllabus/models *
+recursive-include syllabus/utils *
+recursive-include syllabus/saml *

--- a/configuration_default.yaml
+++ b/configuration_default.yaml
@@ -1,36 +1,39 @@
 sessions_secret_key: ~
+default_course: default
+courses:
+  default:
+    title: Syllabus
+    inginious:
+      url: http://inginious_instance.example:port
+      course_id: id
 
-inginious:
-  url: http://inginious_instance.example:port
-  course_id: id
+      # if yes, the INGInious POST requests will be sent to this server instead of the real
+      # INGINious instance. This server will then do the request itself to the INGInious instance,
+      # to avoid same origin policy problem (when the INGInious instance does not allow the use of CORS)
+      same_origin_proxy: yes
 
-  # if yes, the INGInious POST requests will be sent to this server instead of the real
-  # INGINious instance. This server will then do the request itself to the INGInious instance,
-  # to avoid same origin policy problem (when the INGInious instance does not allow the use of CORS)
-  same_origin_proxy: yes
+      # LTI-related config. If you want to use LTI, uncomment the following lines:
 
-  # LTI-related config. If you want to use LTI, uncomment the following lines:
+      #lti:
+      #  consumer_secret: my_super_key
+      #  consumer_key: my_super_consumer_key
 
-  #lti:
-  #  consumer_secret: my_super_key
-  #  consumer_key: my_super_consumer_key
+    pages:
+      # indicates the location where the pages directory is located. It has a lower priority than the SYLLABUS_PAGES_PATH
+      # environment variable. If none of these is set, the path will be considered as in the current working directory.
+      path: ~
 
-pages:
-  # indicates the location where the pages directory is located. It has a lower priority than the SYLLABUS_PAGES_PATH
-  # environment variable. If none of these is set, the path will be considered as in the current working directory.
-  path: ~
-
-  # Git related config. Allows to synchronize the syllabus pages directory with a Git repository.
-  # If you want to use this feature, uncomment the following lines.
-  #git:
-  #  # url of the git remote that will be used to get the pages of the syllabus.
-  #  # the git repo will be force-pulled from the remote
-  #  # if a deployment key is specified and github is used, the string must be in the following format:
-  #  # "git@github.com:user/repo.git"
-  #  remote: ~
-  #  branch: master
-  #  # The path to the private key used to pull the specified repository
-  #  repository_private_key_path: ~
+      # Git related config. Allows to synchronize the syllabus pages directory with a Git repository.
+      # If you want to use this feature, uncomment the following lines.
+      #git:
+      #  # url of the git remote that will be used to get the pages of the syllabus.
+      #  # the git repo will be force-pulled from the remote
+      #  # if a deployment key is specified and github is used, the string must be in the following format:
+      #  # "git@github.com:user/repo.git"
+      #  remote: ~
+      #  branch: master
+      #  # The path to the private key used to pull the specified repository
+      #  repository_private_key_path: ~
 
 
 # Specifies the authentication methods that can be used by the syllabus.

--- a/demo_wsgi/syllabus.wsgi
+++ b/demo_wsgi/syllabus.wsgi
@@ -11,7 +11,7 @@ from syllabus.utils import pages
 # different values for these variables: you only need to duplicate this file
 # and change these variables
 
-ENV_VARS = {"SYLLABUS_PAGES_PATH": None, "SYLLABUS_CONFIG_PATH": None}
+ENV_VARS = {"SYLLABUS_CONFIG_PATH": "/home/syllabus/interactive-syllabus"}
 
 for name, val in ENV_VARS.items():
     if val is not None:
@@ -33,14 +33,17 @@ default_toc = \
     }
 
 # default pages directory location
-path = os.path.join(syllabus.get_root_path(), "pages")
-if 'git' in syllabus.get_config()['pages']:
-    pages.init_and_sync_repo()
-if not os.path.isdir(path) and not os.path.isfile(path):
-        shutil.copytree(os.path.join(syllabus.get_root_path(), "default", "pages"), path)
-if not os.path.isfile(os.path.join(path, "toc.yaml")):
-    with open(os.path.join(path, "toc.yaml"), "w+") as f:
-        yaml.dump(default_toc, f)
+syllabus_config = syllabus.get_config()
+for course in syllabus_config["courses"].keys():
+    path = os.path.join(syllabus.get_pages_path(course))
+    if not os.path.isdir(path) and not os.path.isfile(path):
+            shutil.copytree(os.path.join(syllabus.get_root_path(), "default", "pages"), path)
+    if 'git' in syllabus_config['courses'][course]['pages']:
+        pages.init_and_sync_repo(course)
+
+    if not os.path.isfile(os.path.join(path, "toc.yaml")):
+        with open(os.path.join(path, "toc.yaml"), "w+") as f:
+            yaml.dump(default_toc, f)
 update_database()
 init_db()
 from syllabus.inginious_syllabus import app as application

--- a/syllabus/__init__.py
+++ b/syllabus/__init__.py
@@ -26,28 +26,30 @@ from flask import request, has_request_context
 from syllabus.utils.yaml_ordered_dict import OrderedDictYAMLLoader, OrderedDumper
 
 
-def get_toc(force=False):
+def get_toc(course, force=False):
     def reload_toc():
         """ loads the TOC explicitely """
         # TODO: change this hack a bit ugly
         from syllabus.utils.toc import TableOfContent
-        get_toc.TOC = TableOfContent()
-        return get_toc.TOC
+        get_toc.TOC[course] = TableOfContent(course)
+        return get_toc.TOC[course]
 
     if force:
         return reload_toc()
     else:
         # use cached version
         try:
-            return get_toc.TOC
-        except AttributeError:
+            return get_toc.TOC[course]
+        except KeyError:
             return reload_toc()
 
+get_toc.TOC = {}
 
-def save_toc(TOC):
+
+def save_toc(course, TOC):
     from syllabus.utils.toc import TableOfContent
     """ Dumps the content of the specified TableOfContent in the toc.yaml file. """
-    with open(os.path.join(get_pages_path(), "toc.yaml"), "w") as f:
+    with open(os.path.join(get_pages_path(course), "toc.yaml"), "w") as f:
         yaml.dump(TOC.toc_dict, f, OrderedDumper, default_flow_style=False, allow_unicode=True)
 
 
@@ -55,20 +57,18 @@ def get_root_path():
     return os.path.abspath(os.path.dirname(__file__))
 
 
-def get_pages_path():
+def get_courses():
+    return get_config()['courses'].keys()
+
+
+def get_pages_path(course):
     """
     :return: The path to the content of the "pages" directory. if the syllabus_pages_path variable is set in config.py,
     or if the SYLLABUS_PAGES_PATH environment variable is set in a request context, the returned path will be in the
     specified value (the environment variable has the highest priority)
     If none of these is set, the path will be in the current working directory (os.cwd())
     """
-    # first check if the syllabus_pages_path variable is set
-    if "SYLLABUS_PAGES_PATH" in os.environ:
-        return os.path.join(os.environ["SYLLABUS_PAGES_PATH"], "pages")
-    elif has_request_context() and "SYLLABUS_PAGES_PATH" in request.environ:
-        return os.path.join(request.environ["SYLLABUS_PAGES_PATH"], "pages")
-    # SYLLABUS_PAGES_PATH can be set by mod_wsgi; If not, the path will be in the current working directory
-    syllabus_pages_path = get_config()['pages']['path']
+    syllabus_pages_path = get_config()['courses'][course]['pages']['path']
     path = syllabus_pages_path if syllabus_pages_path is not None else os.getcwd()
     return os.path.join(path, "pages")
 

--- a/syllabus/admin/templates/base.html
+++ b/syllabus/admin/templates/base.html
@@ -26,7 +26,7 @@
 
     <!-- jQuery 3 -->
     <script src="/static/js/jquery-3.1.1.min.js"></script>
-    <script src="http://code.jquery.com/ui/1.10.0/jquery-ui.js"></script>
+    <script src="https://code.jquery.com/ui/1.10.0/jquery-ui.js"></script>
     <!-- Bootstrap 3.3.7 -->
     <script src="/static/js/bootstrap.min.js"></script>
     <!-- AdminLTE App -->

--- a/syllabus/admin/templates/content_edition.html
+++ b/syllabus/admin/templates/content_edition.html
@@ -41,7 +41,7 @@
             <div class="just-padding">
 
                 <div class="list-group list-group-root well">
-                    <a href="/index?edit" class="list-group-item" data-target="#"
+                    <a href="/index/{{ course_str }}?edit" class="list-group-item" data-target="#"
                        data-toggle="collapse" style="padding-left: 15px">
                         Syllabus index
                     </a>
@@ -57,7 +57,7 @@
                                 <i class="chevron fa fa-chevron-down"></i>
                                 {{ content.title }}
                                 <span class="pull-right">
-                                <a href="/syllabus/{{ content.request_path }}?edit"
+                                <a href="/syllabus/{{ course_str }}/{{ content.request_path }}?edit"
                                    target="_blank"
                                    class="btn btn-xs btn-default edit-button" style="margin-left: 5px">
                                     <i class="fa fa-edit"></i>
@@ -87,7 +87,7 @@
                                 {{ content.title }}
                                 <span class="pull-right">
                                     <a class="btn btn-xs btn-default edit-button"
-                                       href="/syllabus/{{ content.request_path }}?edit"
+                                       href="/syllabus/{{ course_str }}/{{ content.request_path }}?edit"
                                        target="_blank"
                                        style="margin-left: 5px">
                                         <i class="fa fa-edit"></i>

--- a/syllabus/admin/templates/edit_configuration.html
+++ b/syllabus/admin/templates/edit_configuration.html
@@ -26,11 +26,13 @@
         </h1>
         <section class="content container-fluid">
             <div id="editor" style="margin: 20px; max-width: 95%" data-language="rst">
-                {% if hook_path is not none %}
-                    <div class="alert alert-info">
-                        Git pages update webhook path: <pre>{{ hook_path }}</pre>
-                    </div>
-                {% endif %}
+                {% for hook_path in hook_paths %}
+                    {% if hook_path is not none %}
+                        <div class="alert alert-info">
+                            Git pages update webhook path: <pre>{{ hook_path }}</pre>
+                        </div>
+                    {% endif %}
+                {% endfor %}
                 <form id="to-submit" method="post">
                     <label for="config">New configuration</label>
                     <textarea id="config" name="new_config"

--- a/syllabus/database.py
+++ b/syllabus/database.py
@@ -56,8 +56,8 @@ def init_db():
     users = User.query.all()
     if len(users) == 0:
         create_db_user()
-    if 'git' in syllabus.get_config()['pages']:
-        generate_github_hook()
+    
+    generate_github_hook()
 
 
 def update_database():

--- a/syllabus/inginious_syllabus.py
+++ b/syllabus/inginious_syllabus.py
@@ -258,7 +258,7 @@ def log_out():
     if "user" in session:
         saml = session["user"].get("login_method", None) == "saml"
         session.pop("user", None)
-        if saml:
+        if saml and "singleLogoutService" in saml_config["sp"]:
             req = prepare_request(request)
             auth = init_saml_auth(req, saml_config)
             return redirect(auth.logout())

--- a/syllabus/templates/rst_page.html
+++ b/syllabus/templates/rst_page.html
@@ -48,6 +48,19 @@
     </script>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
+
+        .navbar-brand-dropdown {
+            margin: 0;
+        }
+
+        .navbar-brand .dropdown-toggle {
+            margin-top: -15px;
+        }
+
+        .dropdown-menu .dropdown-brand {
+            margin-left: -15px;
+        }
+
         .CodeMirror {
             border: 1px solid #eee;
             height: auto;
@@ -80,7 +93,19 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="/">Accueil</a>
+            <ul class="nav navbar-nav navbar-brand navbar-brand-dropdown">
+                <li class="dropdown">
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"> {{ courses_titles[course_str] }} <span class="caret"></span></a>
+                    <ul class="dropdown-menu">
+                        {% for key, course_title in courses_titles.items() %}
+                            <li><a href="/index/{{ key}}">{{ course_title }}</a></li>
+                             {% if not loop.last %}
+                                <li role="separator" class="divider"></li>
+                            {% endif %}
+                        {% endfor %}
+                    </ul>
+                </li>
+            </ul>
         </div>
 
         <!-- Collect the nav links, forms, and other content for toggling -->
@@ -91,7 +116,7 @@
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"> {{ chapter.title }} <span class="caret"></span></a>
                         <ul class="dropdown-menu">
                             {% for content in toc.get_content_at_same_level(chapter) %}
-                                <li><a href="/syllabus/{{ content.request_path }}">{{ content.title }}</a></li>
+                                <li><a href="/syllabus/{{ course_str }}/{{ content.request_path }}">{{ content.title }}</a></li>
                                 {% if not loop.last %}
                                     <li role="separator" class="divider"></li>
                                 {% endif %}
@@ -104,23 +129,23 @@
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"> {{ this_content.title if "Page" in this_content.__class__.__name__ else "Index du chapitre" }} <span class="caret"></span></a>
                         <ul class="dropdown-menu">
                             {% if "Page" in this_content.__class__.__name__ %}
-                                <li><a href="/syllabus/{{ containing_chapters[-1].request_path }}"> Index du chapitre </a></li>
+                                <li><a href="/syllabus/{{ course_str }}/{{ containing_chapters[-1].request_path }}"> Index du chapitre </a></li>
 
                                 <li role="separator" class="divider"></li>
 
                                 {% for content in content_at_same_level %}
-                                <li><a href="/syllabus/{{ content.request_path }}">{{ content.title }}</a></li>
+                                <li><a href="/syllabus/{{ course_str }}/{{ content.request_path }}">{{ content.title }}</a></li>
                                     {% if not loop.last %}
                                         <li role="separator" class="divider"></li>
                                     {% endif %}
                                 {% endfor %}
                             {% else %}
-                                <li><a href="/syllabus/{{ this_content.request_path }}"> Index du chapitre </a></li>
+                                <li><a href="/syllabus/{{ course_str }}/{{ this_content.request_path }}"> Index du chapitre </a></li>
 
                                 <li role="separator" class="divider"></li>
 
                                 {% for content in toc.get_direct_content_of(this_content) %}
-                                    <li><a href="/syllabus/{{ content.request_path }}">{{ content.title }}</a></li>
+                                    <li><a href="/syllabus/{{ course_str }}/{{ content.request_path }}">{{ content.title }}</a></li>
                                     {% if not loop.last %}
                                         <li role="separator" class="divider"></li>
                                     {% endif %}
@@ -142,7 +167,7 @@
                     </li>
                 {% endif %}
                 {% if display_print_all %}
-                    <li><a href="/print_all" style="display: block"> Print syllabus </a></li>
+                    <li><a href="/print_all/{{ course_str }}" style="display: block"> Print syllabus </a></li>
                 {% endif %}
                 <li><a href="{{ "%s?print" % request.path }}" style="display: block">Print page</a></li>
                 {% if "Chapter" in this_content.__class__.__name__ %}
@@ -156,7 +181,7 @@
     <span id="maincontent"></span>
     <div class="box contents">
         <div class="no-overflow">
-            {{ render_rst(this_content, logged_in=logged_in, toc=toc, get_lti_data=get_lti_data, get_lti_submission=get_lti_submission)|safe }}
+            {{ render_rst(this_content, course_str=course_str, logged_in=logged_in, toc=toc, get_lti_data=get_lti_data, get_lti_submission=get_lti_submission)|safe }}
         </div>
     </div>
 
@@ -166,12 +191,12 @@
 {% endif %}
 <div style="display: flex; flex-direction: row; justify-content: space-between">
     {% if previous is not none %}
-        <a href="/syllabus/{{ previous.request_path }}" style="font-size: 120%; margin-left: 35px">Page précédente</a>
+        <a href="/syllabus/{{ course_str }}/{{ previous.request_path }}" style="font-size: 120%; margin-left: 35px">Page précédente</a>
     {% else %}
         <div></div>
     {% endif %}
     {% if next is not none %}
-        <a href="/syllabus/{{ next.request_path }}" style="font-size: 120%; margin-right: 35px">Page suivante</a>
+        <a href="/syllabus/{{ course_str }}/{{ next.request_path }}" style="font-size: 120%; margin-right: 35px">Page suivante</a>
     {% else %}
         <div></div>
     {% endif %}

--- a/syllabus/utils/inginious_lti.py
+++ b/syllabus/utils/inginious_lti.py
@@ -7,20 +7,20 @@ from lti import ToolConsumer
 
 import syllabus
 
-lti_url_regex = re.compile("%s/@[0-9a-fA-F]+@/lti/task/?" % syllabus.get_config()['inginious']['url'])
 lti_regex_match = re.compile('/@([0-9a-fA-F]+?)@/')
 
 
-def get_lti_url(user_id, task_id):
+def get_lti_url(course, user_id, task_id):
     config = syllabus.get_config()
+    inginious_config = config['courses'][course]['inginious']
     consumer = ToolConsumer(
-        consumer_key=config['inginious']['lti']['consumer_key'],
-        consumer_secret=config['inginious']['lti']['consumer_secret'],
-        launch_url='%s/lti/%s/%s' % (config['inginious']['url'], config['inginious']['course_id'], task_id),
+        consumer_key=inginious_config['lti']['consumer_key'],
+        consumer_secret=inginious_config['lti']['consumer_secret'],
+        launch_url='%s/lti/%s/%s' % (inginious_config['url'], inginious_config['course_id'], task_id),
         params={
             'lti_message_type': 'basic-lti-launch-request',
             'lti_version': "1.1",
-            'resource_link_id': "syllabus_%s" % task_id,
+            'resource_link_id': "syllabus_{}_{}".format(course, task_id),
             'user_id': user_id,
         }
     )
@@ -28,11 +28,12 @@ def get_lti_url(user_id, task_id):
     d = consumer.generate_launch_data()
     data = parse.urlencode(d).encode()
 
-    req = urllib_request.Request('%s/lti/%s/%s' % (config['inginious']['url'], config['inginious']['course_id'], task_id), data=data)
+    req = urllib_request.Request('%s/lti/%s/%s' % (inginious_config['url'], inginious_config['course_id'], task_id), data=data)
     resp = urllib_request.urlopen(req)
 
     task_url = resp.geturl()
 
+    lti_url_regex = re.compile("%s/@[0-9a-fA-F]+@/lti/task/?" % inginious_config['url'])
     if not lti_url_regex.match(task_url):
         pass
         #raise Exception("INGInious returned the wrong url: %s vs %s" % (task_url, str(lti_url_regex)))
@@ -54,12 +55,12 @@ def get_lti_submission(user_id, task_id):
     return None
 
 
-def get_lti_data(user_id, task_id):
-    config = syllabus.get_config()
+def get_lti_data(course, user_id, task_id):
+    inginious_config = syllabus.get_config()['courses'][course]['inginious']
     consumer = ToolConsumer(
-        consumer_key=config['inginious']['lti']['consumer_key'],
-        consumer_secret=config['inginious']['lti']['consumer_secret'],
-        launch_url='%s/lti/%s/%s' % (config['inginious']['url'], config['inginious']['course_id'], task_id),
+        consumer_key=inginious_config['lti']['consumer_key'],
+        consumer_secret=inginious_config['lti']['consumer_secret'],
+        launch_url='%s/lti/%s/%s' % (inginious_config['url'], inginious_config['course_id'], task_id),
         params={
             'lti_message_type': 'basic-lti-launch-request',
             'lti_version': "1.1",


### PR DESCRIPTION
Here's a first PoC for a multicourses syllabus/multisyllabi on one app.

Currently it mainly consists in a page diversification by adding an additional course parameter. So admins are admins of every course. This may not be the best way to implement it but it was made quite fast. There is a default course set in the configuration file to be displayed if the app is accessed without mentioning the wanted course. Maybe adding a main page would be interesting.

The whole patched code would certainly worth a good refactor as they are several small hacks that may not be a good idea, mainly for retrocompatibility. For instance:

- The course to be displayed is stored in session to be accessed by rst directives without being passed as an argument (moreover this is non-sense).
- The doctuils.parsers.rst.directives.uri function is also overriden to rewrite the assets URLs to 1) ensures retrocompatibility, 2) to ensures the files are still readable outside of the app (in Github for instance) without breaking the links.

This is currently hosted on https://syllabus-interactif.info.ucl.ac.be/
 