### PR TITLE
remove activation secret from database

### DIFF
--- a/configuration_default.yaml
+++ b/configuration_default.yaml
@@ -112,6 +112,7 @@ authentication_methods:
       smtp_server: mysmtpserver.example # name of the smtp server to which send the activation e-mail
       smtp_server_port: ~ # if not defined, will be set to 465 if use_ssl is yes, it will be set to 25 otherwise
       sender_email_address: noreply@syllabus.example  # e-mail address used by the application to send the activation e-mail
+      secret: activation_secret # Use to generate the hash for the activation link
       authentication:
         required: yes
         username: username

--- a/syllabus/database.py
+++ b/syllabus/database.py
@@ -140,9 +140,9 @@ def update_database():
 
 
 # we cannot register locally if either somebody has the same e-mail
-def locally_register_new_user(user, activation_required=True):
+def locally_register_new_user(user, activated=False):
     from syllabus.models.user import User, UserAlreadyExists
-    user.activated = not activation_required
+    user.activated = activated
     user.right = None
     existing_user = User.query.filter(User.email == user.email).first()
     if existing_user is not None:
@@ -151,12 +151,3 @@ def locally_register_new_user(user, activation_required=True):
     db_session.add(user)
     db_session.commit()
 
-
-def find_user_from_registration_hash(hash):
-    from syllabus.models.user import User, get_activation_hash
-    users = User.query.all()
-    email_activation_config = get_config()["authentication_methods"]["local"].get("email_activation", {})
-    for user in users:
-        if get_activation_hash(user.email, email_activation_config['secret']) == hash:
-            return user
-    return None

--- a/syllabus/models/user.py
+++ b/syllabus/models/user.py
@@ -14,10 +14,9 @@ class User(Base):
     change_password_url = Column(String(50))
     right = Column(String(30))
     activated = Column(Boolean(), nullable=False, default=False)
-    activation_secret = Column(String(80), unique=True, index=True)
 
     def __init__(self, name, email, hash_password, full_name=None, change_password_url=None, right=None,
-                 activated=False, activation_secret=None):
+                 activated=False):
         self.username = name
         self.email = email
         self.hash_password = hash_password
@@ -25,7 +24,6 @@ class User(Base):
         self.change_password_url = change_password_url
         self.right = right
         self.activated = activated
-        self.activation_secret = activation_secret
 
     def to_dict(self):
         return {"username": self.username, "email": self.email, "right": self.right}
@@ -48,11 +46,15 @@ class User(Base):
 
 def hash_password_func(email, password, global_salt, n_iterations):
     if global_salt is None:
-        return sha512(password).hexdigest()
+        return sha512(password.encode()).hexdigest()
     return pbkdf2_hmac('sha512',
                        password=password.encode(),
                        salt=HMAC(global_salt.encode(), email.encode(), sha256).digest(),
                        iterations=n_iterations)
+
+
+def get_activation_hash(email, secret):
+    return HMAC(secret.encode(), email.encode(), sha256).hexdigest()
 
 
 class UserAlreadyExists(Exception):

--- a/syllabus/templates/local_register_confirmed_account.html
+++ b/syllabus/templates/local_register_confirmed_account.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+    <script src="/static/js/jquery-3.1.1.min.js"></script>
+    <link href="/static/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/static/css/signin.css" rel="stylesheet">
+    <script src="/static/js/bootstrap.min.js"></script>
+</head>
+<body>
+    <div class="container">
+        {% if feedback is defined and feedback is not none %}
+            <div class="container-fluid" style="padding-top: 10px">
+                <div class="alert alert-{{ feedback.alert_color }} alert-dismissable">
+                    <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+                    <h4> <i class="fa {{ feedback.icon }}" style="padding-right: 5px"></i> {{ feedback.title }} </h4>
+                    {{ feedback.message | safe }}
+                </div>
+            </div>
+        {% endif %}
+
+      <form class="form-signin" method="post">
+        <h2 class="form-signin-heading">Please register</h2>
+        <label for="inputUsername" class="sr-only">Username</label>
+        <input type="text" id="inputUsername" class="form-control" placeholder="Username" required autofocus name="username">
+        <label for="inputPassword" class="sr-only">Password</label>
+        <input type="password" minlength="6" id="inputPassword" class="form-control" placeholder="Password" required name="password">
+        <label for="repeatPassword" class="sr-only">Confirm password</label>
+        <input type="password" minlength="6" id="repeatPassword" class="form-control" placeholder="Confirm password" required name="confirm-password">
+        <button class="btn btn-lg btn-primary btn-block" type="submit">Register</button>
+      </form>
+
+
+
+    </div> <!-- /container -->
+
+
+</body>
+</html>

--- a/syllabus/templates/register.html
+++ b/syllabus/templates/register.html
@@ -25,12 +25,15 @@
             <h2 class="form-signin-heading">Please register</h2>
             <label for="inputUsername" class="sr-only">E-mail</label>
             <input type="text" id="inputEmail" class="form-control" placeholder="E-mail" required name="email">
-            <label for="inputUsername" class="sr-only">Username</label>
-            <input type="text" id="inputUsername" class="form-control" placeholder="Username" required autofocus name="username">
-            <label for="inputPassword" class="sr-only">Password</label>
-            <input type="password" minlength="6" id="inputPassword" class="form-control" placeholder="Password" required name="password">
-            <label for="repeatPassword" class="sr-only">Confirm password</label>
-            <input type="password" minlength="6" id="repeatPassword" class="form-control" placeholder="Confirm password" required name="confirm-password">
+
+            {% if not activation_required %}
+                <label for="inputUsername" class="sr-only">Username</label>
+                <input type="text" id="inputUsername" class="form-control" placeholder="Username" required autofocus name="username">
+                <label for="inputPassword" class="sr-only">Password</label>
+                <input type="password" minlength="6" id="inputPassword" class="form-control" placeholder="Password" required name="password">
+                <label for="repeatPassword" class="sr-only">Confirm password</label>
+                <input type="password" minlength="6" id="repeatPassword" class="form-control" placeholder="Confirm password" required name="confirm-password">
+            {% endif %}
             <button class="btn btn-lg btn-primary btn-block" type="submit">Register</button>
           </form>
 


### PR DESCRIPTION
Remove the activation hash (if needed after registering) from the database. Instead it is computed from the mail of the user, with a secret in the configuration.
Maybe we should add something more than the user email in the hash computation?